### PR TITLE
Add extension scaffold: manifest, options page, and source stubs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Anghami Plus",
+  "version": "1.0.0",
+  "description": "Better lyrics experience on kalimat.anghami.com",
+  "permissions": ["storage"],
+  "host_permissions": ["*://kalimat.anghami.com/*"],
+  "background": {
+    "service_worker": "dist/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://kalimat.anghami.com/lyrics/*"],
+      "js": ["dist/content.js"],
+      "css": ["styles.css"]
+    }
+  ],
+  "action": {
+    "default_popup": "options.html"
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anghami Plus Options</title>
+  </head>
+  <body>
+    <script src="dist/options.js"></script>
+  </body>
+</html>

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,1 +1,1 @@
-export {};
+console.log('[anghami-plus] content script loaded');


### PR DESCRIPTION
## Summary
- Adds `manifest.json` (Manifest V3) with storage permission, host_permissions for kalimat.anghami.com, background service worker, content script on `/lyrics/*`, and options popup
- Adds `options.html` shell linking to `dist/options.js`
- Adds empty `styles.css`
- Updates `src/content.ts` with console log, keeps `src/background.ts` and `src/options.ts` as stubs

## Test plan
- [ ] Extension loads in Chrome without errors
- [ ] Options page opens from extension icon
- [ ] Content script logs `[anghami-plus] content script loaded` on target page

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)