### PR TITLE
Add deploy workflow: CDK deploy on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: cdk/package-lock.json
+
+      - name: Install CDK dependencies
+        run: npm ci
+        working-directory: cdk
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy CDK stack
+        run: npx cdk deploy --require-approval never -c apiSecret=${{ secrets.API_SECRET }}
+        working-directory: cdk


### PR DESCRIPTION
## Summary
New `deploy.yml` workflow triggers on every push to `main` (i.e. after merge). It installs CDK deps, configures AWS credentials, and runs `cdk deploy`.

## Required GitHub repository secrets
Set these in **Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| `AWS_ACCESS_KEY_ID` | IAM user access key with CDK deploy permissions |
| `AWS_SECRET_ACCESS_KEY` | Corresponding secret key |
| `AWS_REGION` | e.g. `us-east-1` |
| `API_SECRET` | The shared secret checked by the Lambda handler |

Note: run `cdk bootstrap` once manually before the first deploy if the AWS environment hasn't been bootstrapped yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)