### PR TITLE
Align deploy workflow with nycares: OIDC, SSM secret, vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,18 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
-permissions:
-  contents: read
+concurrency:
+  group: deploy
+  cancel-in-progress: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -19,16 +24,27 @@ jobs:
           cache: npm
           cache-dependency-path: cdk/package-lock.json
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upsert API secret to SSM
+        run: |
+          aws ssm put-parameter \
+            --name "/anghami-plus/api-secret" \
+            --value "${{ secrets.API_SECRET }}" \
+            --type SecureString \
+            --overwrite
+
       - name: Install CDK dependencies
         run: npm ci
         working-directory: cdk
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
       - name: Deploy CDK stack
-        run: npx cdk deploy --require-approval never -c apiSecret=${{ secrets.API_SECRET }}
         working-directory: cdk
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+        run: npx cdk deploy --require-approval never

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -3,4 +3,9 @@ import * as cdk from 'aws-cdk-lib';
 import { AnghamiPlusStack } from '../lib/stack';
 
 const app = new cdk.App();
-new AnghamiPlusStack(app, 'AnghamiPlusStack');
+new AnghamiPlusStack(app, 'AnghamiPlusStack', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -3,14 +3,14 @@ import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+
+const SSM_SECRET_PATH = '/anghami-plus/api-secret';
 
 export class AnghamiPlusStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-
-    const apiSecret = this.node.tryGetContext('apiSecret') as string | undefined;
-    if (!apiSecret) throw new Error('Required: cdk deploy -c apiSecret=<value>');
 
     const fn = new lambdaNodejs.NodejsFunction(this, 'ProxyFunction', {
       functionName: 'anghami-plus-proxy',
@@ -18,8 +18,27 @@ export class AnghamiPlusStack extends cdk.Stack {
       entry: path.join(__dirname, '../src/handler/index.ts'),
       handler: 'handler',
       timeout: cdk.Duration.seconds(30),
-      environment: { API_SECRET: apiSecret },
+      environment: { SSM_SECRET_PATH },
     });
+
+    // Lambda reads the secret from SSM at runtime
+    fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [
+          `arn:aws:ssm:${this.region}:${this.account}:parameter${SSM_SECRET_PATH}`,
+        ],
+      })
+    );
+    fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['kms:Decrypt'],
+        resources: ['*'],
+        conditions: {
+          StringEquals: { 'kms:ViaService': `ssm.${this.region}.amazonaws.com` },
+        },
+      })
+    );
 
     fn.addToRolePolicy(
       new iam.PolicyStatement({

--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -2,10 +2,30 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
+import {
+  SSMClient,
+  GetParameterCommand,
+} from '@aws-sdk/client-ssm';
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 
-const client = new BedrockRuntimeClient({});
+const bedrockClient = new BedrockRuntimeClient({});
+const ssmClient = new SSMClient({});
 const MODEL_ID = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+
+// Cached after first warm-up; survives across invocations in the same execution environment
+let cachedSecret: string | undefined;
+
+async function getApiSecret(): Promise<string> {
+  if (cachedSecret) return cachedSecret;
+  const res = await ssmClient.send(
+    new GetParameterCommand({
+      Name: process.env.SSM_SECRET_PATH,
+      WithDecryption: true,
+    })
+  );
+  cachedSecret = res.Parameter!.Value!;
+  return cachedSecret;
+}
 
 const PROMPTS = {
   translate: (lyrics: string) =>
@@ -33,7 +53,9 @@ function jsonResponse(
 export const handler = async (
   event: APIGatewayProxyEventV2
 ): Promise<APIGatewayProxyResultV2> => {
-  if (event.headers['x-api-secret'] !== process.env.API_SECRET) {
+  const apiSecret = await getApiSecret();
+
+  if (event.headers['x-api-secret'] !== apiSecret) {
     return jsonResponse(401, { error: 'Unauthorized' });
   }
 
@@ -47,7 +69,9 @@ export const handler = async (
   const { action, lyrics } = parsed;
 
   if (!lyrics || (action !== 'translate' && action !== 'harakat')) {
-    return jsonResponse(400, { error: 'action must be "translate" or "harakat", lyrics required' });
+    return jsonResponse(400, {
+      error: 'action must be "translate" or "harakat", lyrics required',
+    });
   }
 
   const prompt = PROMPTS[action](lyrics);
@@ -64,7 +88,7 @@ export const handler = async (
       }),
     });
 
-    const response = await client.send(command);
+    const response = await bedrockClient.send(command);
     const payload = JSON.parse(new TextDecoder().decode(response.body)) as {
       content: { text: string }[];
     };


### PR DESCRIPTION
## Summary
- **OIDC auth**: replaced long-lived `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` with `role-to-assume: ${{ secrets.AWS_ROLE_ARN }}`
- **SSM for secret**: CI upserts `API_SECRET` to `/anghami-plus/api-secret` as SecureString before deploy; Lambda reads + caches it at runtime (not visible in Lambda console)
- **vars for non-sensitive config**: `AWS_REGION` and `AWS_ACCOUNT_ID` moved to repository variables
- **Concurrency group**: prevents overlapping deploys
- **workflow_dispatch**: allows manual re-deploys from GitHub UI

## Required setup
**Secrets** (Settings → Secrets):
| Secret | Value |
|---|---|
| `AWS_ROLE_ARN` | IAM role ARN with CDK deploy permissions and OIDC trust for `repo:Bouzomgi/anghami-plus:ref:refs/heads/main` |
| `API_SECRET` | Shared secret checked by the Lambda handler |

**Variables** (Settings → Variables):
| Variable | Value |
|---|---|
| `AWS_REGION` | e.g. `us-east-1` |
| `AWS_ACCOUNT_ID` | Your 12-digit AWS account ID |

🤖 Generated with [Claude Code](https://claude.com/claude-code)