### PR TITLE
Fix EOL model, manifest host_permissions, font swap

### DIFF
--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -55,7 +55,7 @@ export class AnghamiPlusStack extends cdk.Stack {
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0`,
+          `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
         ],
       })
     );

--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -17,7 +17,7 @@ import type {
 const bedrockClient = new BedrockRuntimeClient({});
 const s3Client = new S3Client({});
 const ssmClient = new SSMClient({});
-const MODEL_ID = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+const MODEL_ID = 'anthropic.claude-3-7-sonnet-20250219-v1:0';
 
 let cachedSecret: string | undefined;
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,10 @@
   "version": "1.0.0",
   "description": "Better lyrics experience on kalimat.anghami.com",
   "permissions": ["storage"],
-  "host_permissions": ["*://kalimat.anghami.com/*"],
+  "host_permissions": [
+    "*://kalimat.anghami.com/*",
+    "https://*.lambda-url.us-east-1.on.aws/*"
+  ],
   "background": {
     "service_worker": "dist/background.js"
   },

--- a/src/content.ts
+++ b/src/content.ts
@@ -8,7 +8,7 @@ function injectFont(): void {
   link.id = 'anghami-plus-font';
   link.rel = 'stylesheet';
   link.href =
-    'https://fonts.googleapis.com/css2?family=Amiri:ital@0;1&display=swap';
+    'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic&display=swap';
   document.head.appendChild(link);
 }
 
@@ -54,7 +54,7 @@ function findLyricsContainer(): HTMLElement | null {
 }
 
 function applyFont(el: HTMLElement): void {
-  el.style.fontFamily = '"Amiri", serif';
+  el.style.fontFamily = '"Noto Naskh Arabic", serif';
   el.style.fontSize = '1.3rem';
   el.style.lineHeight = '2.2';
   el.style.direction = 'rtl';


### PR DESCRIPTION
## Summary
- Bedrock model updated from `claude-3-5-sonnet-20241022-v2:0` (EOL) to `claude-3-7-sonnet-20250219-v1:0`
- `manifest.json`: added `https://*.lambda-url.us-east-1.on.aws/*` to `host_permissions` so the background service worker can fetch the Lambda
- Font swapped from Amiri to Noto Naskh Arabic

🤖 Generated with [Claude Code](https://claude.com/claude-code)