### PR TITLE
Add inference profile ARN to Bedrock IAM policy

### DIFF
--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -56,6 +56,7 @@ export class AnghamiPlusStack extends cdk.Stack {
         actions: ['bedrock:InvokeModel'],
         resources: [
           `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0`,
         ],
       })
     );


### PR DESCRIPTION
Cross-region inference profiles (`us.anthropic.*`) use a different ARN format than foundation models and need an explicit resource entry in the IAM policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)