### PR TITLE
Allow bedrock:InvokeModel across all regions for cross-region inference profile

### DIFF
--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -55,7 +55,7 @@ export class AnghamiPlusStack extends cdk.Stack {
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
+          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
           `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0`,
         ],
       })


### PR DESCRIPTION
The `us.` cross-region inference profile routes requests to `us-east-1`, `us-east-2`, and `us-west-2`. The foundation model ARN in the IAM policy was locked to `${this.region}` (us-east-1), causing auth failures when Bedrock routed to another region. Widened to `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)