### PR TITLE
Switch to Amazon Nova Pro

### DIFF
--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -55,8 +55,8 @@ export class AnghamiPlusStack extends cdk.Stack {
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
-          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0`,
+          `arn:aws:bedrock:*::foundation-model/amazon.nova-pro-v1:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.amazon.nova-pro-v1:0`,
         ],
       })
     );

--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -17,7 +17,7 @@ import type {
 const bedrockClient = new BedrockRuntimeClient({});
 const s3Client = new S3Client({});
 const ssmClient = new SSMClient({});
-const MODEL_ID = 'us.anthropic.claude-3-7-sonnet-20250219-v1:0';
+const MODEL_ID = 'us.amazon.nova-pro-v1:0';
 
 let cachedSecret: string | undefined;
 
@@ -123,18 +123,17 @@ export const handler = async (
       contentType: 'application/json',
       accept: 'application/json',
       body: JSON.stringify({
-        anthropic_version: 'bedrock-2023-05-31',
-        max_tokens: 4096,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: [{ text: prompt }] }],
+        inferenceConfig: { max_new_tokens: 4096 },
       }),
     });
 
     const response = await bedrockClient.send(command);
     const payload = JSON.parse(new TextDecoder().decode(response.body)) as {
-      content: { text: string }[];
+      output: { message: { content: { text: string }[] } };
     };
 
-    const result = payload.content[0].text;
+    const result = payload.output.message.content[0].text;
 
     if (bucket) await putToS3(bucket, s3Key, result);
 


### PR DESCRIPTION
Swaps Claude 3.7 Sonnet for Amazon Nova Pro (`us.amazon.nova-pro-v1:0`) to avoid Bedrock Marketplace subscription requirements. Updates the request/response body format and IAM policy resource ARNs accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)