### PR TITLE
Preserve line formatting in harakat and strip fatha server-side

### DIFF
--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -133,7 +133,8 @@ export const handler = async (
       output: { message: { content: { text: string }[] } };
     };
 
-    const result = payload.output.message.content[0].text;
+    const raw = payload.output.message.content[0].text;
+    const result = action === 'harakat' ? raw.replace(/[\u064E\u064B]/g, '') : raw;
 
     if (bucket) await putToS3(bucket, s3Key, result);
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -204,7 +204,7 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
   lyricsEl.appendChild(lyricsBody);
 
   const originalHTML = lyricsBody.innerHTML;
-  const originalText = lyricsBody.textContent ?? '';
+  const originalText = lyricsBody.innerText;
   let harakated: string | null = null;
   let showingHarakat = false;
 
@@ -221,7 +221,7 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
         }
         harakated = res.result;
       }
-      lyricsBody.textContent = harakated;
+      lyricsBody.innerHTML = harakated.replace(/\n/g, '<br>');
       btn.textContent = 'Hide Harakat';
       showingHarakat = true;
     } else {


### PR DESCRIPTION
- Use `innerText` instead of `textContent` when extracting lyrics so line breaks are preserved in the harakat request
- Restore harakated text as `innerHTML` with `<br>` tags to maintain original line structure
- Strip fatha (U+064E) and tanwin-fatha (U+064B) unconditionally on the server after model response

🤖 Generated with [Claude Code](https://claude.com/claude-code)