### PR TITLE
Strip non-tanwin harakat from word-final letters

### DIFF
--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -134,7 +134,16 @@ export const handler = async (
     };
 
     const raw = payload.output.message.content[0].text;
-    const result = action === 'harakat' ? raw.replace(/\u064E/g, '') : raw;
+    const result =
+      action === 'harakat'
+        ? raw
+            .replace(/\u064E/g, '') // strip fatha
+            .replace( // strip non-tanwin harakat from word-final letters
+              /([\u0600-\u06FF])([\u064B-\u0652]*)(?=[^\u0600-\u06FF\u064B-\u0652]|$)/gm,
+              (_, letter: string, harakat: string) =>
+                letter + harakat.replace(/[\u064F\u0650\u0651\u0652]/g, '')
+            )
+        : raw;
 
     if (bucket) await putToS3(bucket, s3Key, result);
 


### PR DESCRIPTION
After the model responds, removes damma, kasra, shadda, and sukun (U+064F, U+0650, U+0651, U+0652) from the last letter of each word. Tanwin marks (U+064B–U+064D) on word-final letters are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)