### PR TITLE
Tell harakat model lyrics are colloquial dialect not fusha

### DIFF
--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -39,6 +39,8 @@ const PROMPTS = {
 
   harakat: (lyrics: string) =>
     `Add harakat (diacritical marks) to these Arabic song lyrics.\n` +
+    `These are song lyrics written in colloquial Arabic dialect (ammiyya), not Modern Standard Arabic (fusha). ` +
+    `Apply harakat according to how the words are actually pronounced in dialect, not their fusha equivalents.\n` +
     `Rules:\n` +
     `- INCLUDE: kasra (\\u0650), damma (\\u064F), shadda (\\u0651), sukun (\\u0652), tanwin kasra (\\u064D), tanwin damma (\\u064C), tanwin fatha (\\u064B)\n` +
     `- DO NOT ADD: fatha (\\u064E) — omit entirely\n` +


### PR DESCRIPTION
Adds dialect context to the harakat prompt so the model applies diacritics based on how words are actually pronounced in ammiyya rather than defaulting to fusha pronunciation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)