### PR TITLE
Fix harakat: strip backslashes, preserve structure on toggle, lock scroll

### DIFF
--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -139,6 +139,7 @@ export const handler = async (
     const result =
       action === 'harakat'
         ? raw
+            .replace(/\\/g, '') // strip model-artifact backslashes
             .replace(/\u064E/g, '') // strip fatha
             .replace( // strip non-tanwin harakat from word-final letters
               /([\u0600-\u06FF])([\u064B-\u0652]*)(?=[^\u0600-\u06FF\u064B-\u0652]|$)/gm,

--- a/src/content.ts
+++ b/src/content.ts
@@ -185,12 +185,6 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
   const originalHTML = lyricsBody.innerHTML;
   const originalText = lyricsBody.innerText;
 
-  // Capture line styles from original so harakat view matches visually
-  const sampleLine =
-    lyricsBody.querySelector<HTMLElement>('p, div, span') ?? lyricsBody;
-  const cs = getComputedStyle(sampleLine);
-  const lineCSS = `font-weight:${cs.fontWeight};margin-top:${cs.marginTop};margin-bottom:${cs.marginBottom};padding-top:${cs.paddingTop};padding-bottom:${cs.paddingBottom};`;
-
   let harakated: string | null = null;
   let showingHarakat = false;
 
@@ -207,14 +201,28 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
         }
         harakated = res.result;
       }
-      lyricsBody.innerHTML = harakated
-        .split('\n')
-        .map((line) => `<p style="${lineCSS}">${line}</p>`)
-        .join('');
+      const scrollY = window.scrollY;
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = originalHTML;
+      const lineEls = Array.from(wrapper.querySelectorAll<HTMLElement>('p'));
+      const harakatLines = harakated.split('\n');
+      if (lineEls.length > 0) {
+        lineEls.forEach((el, i) => {
+          if (i < harakatLines.length) el.innerHTML = harakatLines[i];
+        });
+        lyricsBody.innerHTML = wrapper.innerHTML;
+      } else {
+        lyricsBody.innerHTML = harakatLines
+          .map((line) => `<p>${line}</p>`)
+          .join('');
+      }
+      window.scrollTo(0, scrollY);
       btn.textContent = 'Hide Harakat';
       showingHarakat = true;
     } else {
+      const scrollY = window.scrollY;
       lyricsBody.innerHTML = originalHTML;
+      window.scrollTo(0, scrollY);
       btn.textContent = 'Show Harakat';
       showingHarakat = false;
     }


### PR DESCRIPTION
## Summary
- Strip model-artifact backslashes from harakat output in Lambda (was rendering `\` at end of every line)
- Clone original HTML structure when displaying harakat instead of creating new `<p>` tags — preserves all CSS classes/margins so styling matches exactly
- Save/restore `window.scrollY` around innerHTML swaps to prevent page jump on toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)