### PR TITLE
Fix harakat toggle margins: handle pre element, add visual test harness

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -205,11 +205,16 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
       const wrapper = document.createElement('div');
       wrapper.innerHTML = originalHTML;
       const lineEls = Array.from(wrapper.querySelectorAll<HTMLElement>('p'));
+      const preEl = wrapper.querySelector<HTMLElement>('pre');
       const harakatLines = harakated.split('\n');
       if (lineEls.length > 0) {
+        const nonEmpty = harakatLines.filter((l) => l.trim() !== '');
         lineEls.forEach((el, i) => {
-          if (i < harakatLines.length) el.innerHTML = harakatLines[i];
+          if (i < nonEmpty.length) el.innerHTML = nonEmpty[i];
         });
+        lyricsBody.innerHTML = wrapper.innerHTML;
+      } else if (preEl) {
+        preEl.textContent = harakated;
         lyricsBody.innerHTML = wrapper.innerHTML;
       } else {
         lyricsBody.innerHTML = harakatLines

--- a/test/visual.html
+++ b/test/visual.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Anghami Plus — Visual Test</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        background: #f5f5f5;
+        font-family: sans-serif;
+      }
+      .album-section {
+        background: white;
+        padding: 20px 80px;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        direction: rtl;
+      }
+      .lyrics-page-module__crH_KW__lyrics_body {
+        padding: 40px 80px;
+      }
+      /* Matches Anghami's actual pre styles */
+      pre.lyrics-body-module__ekz3TW__lyrics_body_container {
+        font-family: 'Geeza Pro', serif;
+        font-size: 28px;
+        line-height: 1.7;
+        margin: 0;
+        padding: 0 40px 0 0;
+        text-align: right;
+        white-space: pre-wrap;
+        direction: rtl;
+        color: rgb(0, 0, 0);
+        font-weight: 400;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- img src must contain "anghcdn.co" for the content script to activate -->
+    <section class="album-section">
+      <img
+        src="https://anghcdn.co/fake-for-testing.jpg"
+        style="width: 80px; height: 80px; object-fit: cover; background: #ccc"
+        onerror="this.style.background='#ccc'"
+      />
+      <strong>زفوا القمر — الوليد الحلاني</strong>
+    </section>
+
+    <div class="lyrics-page-module__crH_KW__lyrics_body">
+      <div class="lyrics-page-module__crH_KW__lyrics">
+        <pre class="lyrics-body-module__ekz3TW__lyrics_body_container">زفوا القمر يا أهل الدار القمر ماشي غندرة
+ عم بيغنوا حجار الدار عروستنا منورة
+ زفوا القمر يا أهل الدار القمر ماشي غندرة
+ عم بيغنوا حجار الدار عروستنا منورة
+
+ الله، الله يحميكي يا أختي ويهنيكي
+ برقص خيل بضوي الليل كل ما بطلع فيكي
+ ويا وجه الخير عليّ ظلي شمس مضوية
+ نقيتي أحلى عريس قلبه مثل السكرة
+
+ زفوا القمر يا أهل الدار القمر ماشي غندرة
+ عم بيغنوا حجار الدار عروستنا منورة</pre>
+      </div>
+    </div>
+
+    <script>
+      // Mock Chrome extension API
+      window.chrome = {
+        runtime: {
+          sendMessage: function (msg, callback) {
+            if (msg.action === 'harakat') {
+              setTimeout(function () {
+                callback({
+                  result:
+                    'زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة\n زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة\n \n اللَّه، اللَّه يِحمِيكِي يا أُختِي وِيهَنِّيكِي\n بِرقُص خَيْل بِضَوِي اللَّيْل كُل ما بِطْلَع فِيكِي\n وِيا وِجّه الخَيْر عَلَيّ ظَلِّي شَمْس مَضوِيّة\n نِقِيتِي أَحْلى عَرِيس قَلبُه مِثْل السَّكَرة\n \n زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة',
+                });
+              }, 300);
+            } else {
+              callback({ error: 'Unknown action' });
+            }
+          },
+        },
+        storage: {
+          local: {
+            get: function (keys, cb) {
+              cb({});
+            },
+            set: function (data, cb) {
+              if (cb) cb();
+            },
+          },
+        },
+      };
+    </script>
+    <script src="../dist/content.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Root cause of margin jump: Anghami renders lyrics in a `<pre>` element (not `<p>` tags), so `querySelectorAll('p')` returned nothing and we fell back to creating bare `<p>` tags without original CSS classes
- Fix: detect `<pre>` container and set `textContent` directly — preserves the element with all its CSS classes so harakat/no-harakat views are layout-identical
- Also filter empty lines before matching `<p>` elements (double newlines from `innerText` produced empty string entries)
- Add `test/visual.html`: local test harness with mocked chrome API + real Anghami HTML structure, so Claude can use Puppeteer to screenshot before/after toggle without needing the live site

## Test plan
- [ ] Open `test/visual.html` in browser (or via Puppeteer), click Show/Hide Harakat — layout should not shift
- [ ] Rebuild extension and test on real Anghami page

🤖 Generated with [Claude Code](https://claude.com/claude-code)