### PR TITLE
Add English translation toggle below lyrics

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -234,6 +234,61 @@ function renderHarakatToggle(lyricsEl: HTMLElement): void {
   });
 }
 
+// ── Translation ───────────────────────────────────────────────────────────────
+
+function renderTranslation(lyricsEl: HTMLElement): void {
+  const originalText = document.getElementById(
+    'anghami-plus-lyrics-body'
+  )!.innerText;
+
+  const section = document.createElement('div');
+  section.id = 'anghami-plus-translation';
+  section.style.cssText =
+    'margin-top:2rem;padding-top:1.5rem;border-top:1px solid #ddd;font-family:system-ui,sans-serif;direction:ltr;text-align:left;';
+
+  const btn = document.createElement('button');
+  btn.id = 'anghami-plus-translate-btn';
+  btn.textContent = 'Show Translation';
+  btn.style.cssText =
+    'padding:0.3rem 0.85rem;background:#6c3fa0;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.85rem;white-space:nowrap;';
+
+  const body = document.createElement('div');
+  body.id = 'anghami-plus-translation-body';
+  body.style.cssText =
+    'display:none;margin-top:1rem;font-size:1rem;line-height:1.8;color:#333;white-space:pre-wrap;';
+
+  section.appendChild(btn);
+  section.appendChild(body);
+  lyricsEl.appendChild(section);
+
+  let translated: string | null = null;
+  let showing = false;
+
+  btn.addEventListener('click', async () => {
+    if (!showing) {
+      if (!translated) {
+        btn.textContent = 'Loading…';
+        btn.disabled = true;
+        const res = await callLambda('translate', originalText);
+        btn.disabled = false;
+        if (res.error || !res.result) {
+          btn.textContent = `Error: ${res.error ?? 'unknown'}`;
+          return;
+        }
+        translated = res.result;
+      }
+      body.textContent = translated;
+      body.style.display = 'block';
+      btn.textContent = 'Hide Translation';
+      showing = true;
+    } else {
+      body.style.display = 'none';
+      btn.textContent = 'Show Translation';
+      showing = false;
+    }
+  });
+}
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 let inited = false;
@@ -251,7 +306,7 @@ function tryCleanup(): void {
     injectFont();
     cleanupPage();
     renderHarakatToggle(lyrics);
-    // renderTranslation(lyrics);
+    renderTranslation(lyrics);
   }
 }
 

--- a/test/visual.html
+++ b/test/visual.html
@@ -76,6 +76,13 @@
                     'زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة\n زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة\n \n اللَّه، اللَّه يِحمِيكِي يا أُختِي وِيهَنِّيكِي\n بِرقُص خَيْل بِضَوِي اللَّيْل كُل ما بِطْلَع فِيكِي\n وِيا وِجّه الخَيْر عَلَيّ ظَلِّي شَمْس مَضوِيّة\n نِقِيتِي أَحْلى عَرِيس قَلبُه مِثْل السَّكَرة\n \n زِفُّوا القَمَر يا أَهْل الدّار القَمَر ماشِي غَنْدَرة\n عِم بِيغَنُّوا حِجّار الدّار عَروسِتنا مَنوَّرة',
                 });
               }, 300);
+            } else if (msg.action === 'translate') {
+              setTimeout(function () {
+                callback({
+                  result:
+                    'Carry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place\nCarry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place\n\nGod bless you, my sister, and bring you joy\nLike a horse dancing in moonlight every time it appears before you\nAnd the face of goodness shines upon you like a radiant sun\nYou chose the finest groom, his heart sweet as sugar\n\nCarry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place',
+                });
+              }, 300);
             } else {
               callback({ error: 'Unknown action' });
             }


### PR DESCRIPTION
## Summary
- Adds a "Show Translation" button below a divider under the Arabic lyrics
- Calls the existing Lambda `translate` action on first click, caches result in memory
- Translation displayed as left-to-right plain text with `white-space: pre-wrap`
- Toggle hides/shows without re-fetching
- Visual test harness updated with mock translate response

🤖 Generated with [Claude Code](https://claude.com/claude-code)