### PR TITLE
Set tab title to Arabic song name

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -307,6 +307,8 @@ function tryCleanup(): void {
     cleanupPage();
     renderHarakatToggle(lyrics);
     renderTranslation(lyrics);
+    const songTitle = document.querySelector('h1')?.textContent?.trim();
+    if (songTitle) document.title = songTitle;
   }
 }
 


### PR DESCRIPTION
## Summary
- Sets `document.title` to the `<h1>` text (Arabic song name) on init
- Replaces the long default title like "كلمات أغنية زفوا القمر الوليد الحلاني Zeffo El Amar by Al Walid El Hallani"

🤖 Generated with [Claude Code](https://claude.com/claude-code)