### PR TITLE
Add didactic word breakdown feature

### DIFF
--- a/cdk/src/handler/index.ts
+++ b/cdk/src/handler/index.ts
@@ -45,6 +45,16 @@ const PROMPTS = {
     `- INCLUDE: kasra (\\u0650), damma (\\u064F), shadda (\\u0651), sukun (\\u0652), tanwin kasra (\\u064D), tanwin damma (\\u064C), tanwin fatha (\\u064B)\n` +
     `- DO NOT ADD: fatha (\\u064E) — omit entirely\n` +
     `Return only the harakated text, preserving line breaks.\n\n${lyrics}`,
+
+  breakdown: (lyrics: string) =>
+    `You are helping a student learn colloquial Arabic through song lyrics.\n` +
+    `For each non-empty line, provide:\n` +
+    `1. A natural English translation of the full line\n` +
+    `2. 2-4 key phrases worth learning — focus on interesting vocabulary, idioms, or constructions; skip trivial words if they stand alone\n\n` +
+    `These are dialect (ammiyya) lyrics, not Modern Standard Arabic.\n\n` +
+    `Return a JSON array with no markdown or code fences. Each element:\n` +
+    `{"arabic":"original line","translation":"English translation","phrases":[{"arabic":"key phrase","english":"meaning"}]}\n\n` +
+    `Lyrics:\n${lyrics}`,
 };
 
 function jsonResponse(
@@ -102,7 +112,7 @@ export const handler = async (
 
   const { action, lyrics } = parsed;
 
-  if (!lyrics || (action !== 'translate' && action !== 'harakat')) {
+  if (!lyrics || (action !== 'translate' && action !== 'harakat' && action !== 'breakdown')) {
     return jsonResponse(400, {
       error: 'action must be "translate" or "harakat", lyrics required',
     });
@@ -126,7 +136,7 @@ export const handler = async (
       accept: 'application/json',
       body: JSON.stringify({
         messages: [{ role: 'user', content: [{ text: prompt }] }],
-        inferenceConfig: { max_new_tokens: 4096 },
+        inferenceConfig: { max_new_tokens: 8192 },
       }),
     });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 import { LAMBDA_URL, API_SECRET } from './config';
 
-type Action = 'translate' | 'harakat';
+type Action = 'translate' | 'harakat' | 'breakdown';
 
 interface LambdaRequest {
   action: Action;
@@ -18,7 +18,11 @@ chrome.runtime.onMessage.addListener(
     _sender: chrome.runtime.MessageSender,
     sendResponse: (r: LambdaResponse) => void
   ) => {
-    if (msg.action !== 'translate' && msg.action !== 'harakat') {
+    if (
+      msg.action !== 'translate' &&
+      msg.action !== 'harakat' &&
+      msg.action !== 'breakdown'
+    ) {
       sendResponse({ error: 'Unknown action' });
       return false;
     }

--- a/src/content.ts
+++ b/src/content.ts
@@ -147,7 +147,7 @@ function cleanupPage(): void {
 
 // ── Lambda messaging + local cache ────────────────────────────────────────────
 
-type Action = 'translate' | 'harakat';
+type Action = 'translate' | 'harakat' | 'breakdown';
 
 async function callLambda(
   action: Action,
@@ -289,6 +289,85 @@ function renderTranslation(lyricsEl: HTMLElement): void {
   });
 }
 
+// ── Word breakdown ────────────────────────────────────────────────────────────
+
+interface LineBreakdown {
+  arabic: string;
+  translation: string;
+  phrases: { arabic: string; english: string }[];
+}
+
+function renderBreakdown(lyricsEl: HTMLElement): void {
+  const originalText = document.getElementById(
+    'anghami-plus-lyrics-body'
+  )!.innerText;
+
+  const section = document.createElement('div');
+  section.id = 'anghami-plus-breakdown';
+  section.style.cssText =
+    'margin-top:2rem;padding-top:1.5rem;border-top:1px solid #ddd;font-family:system-ui,sans-serif;direction:ltr;text-align:left;';
+
+  const btn = document.createElement('button');
+  btn.id = 'anghami-plus-breakdown-btn';
+  btn.textContent = 'Show Word Breakdown';
+  btn.style.cssText =
+    'padding:0.3rem 0.85rem;background:#6c3fa0;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.85rem;white-space:nowrap;';
+
+  const body = document.createElement('div');
+  body.style.cssText = 'display:none;margin-top:1.5rem;';
+
+  section.appendChild(btn);
+  section.appendChild(body);
+  lyricsEl.appendChild(section);
+
+  let breakdown: LineBreakdown[] | null = null;
+  let showing = false;
+
+  btn.addEventListener('click', async () => {
+    if (!showing) {
+      if (!breakdown) {
+        btn.textContent = 'Loading…';
+        btn.disabled = true;
+        const res = await callLambda('breakdown', originalText);
+        btn.disabled = false;
+        if (res.error || !res.result) {
+          btn.textContent = `Error: ${res.error ?? 'unknown'}`;
+          return;
+        }
+        try {
+          const cleaned = res.result
+            .replace(/^```(?:json)?\s*/m, '')
+            .replace(/\s*```$/m, '')
+            .trim();
+          breakdown = JSON.parse(cleaned) as LineBreakdown[];
+        } catch {
+          btn.textContent = 'Error: could not parse response';
+          return;
+        }
+      }
+      body.innerHTML = breakdown
+        .map(
+          (line) => `
+          <div style="margin-bottom:2rem;">
+            <div style="font-family:'Geeza Pro',serif;font-size:1.2rem;direction:rtl;text-align:right;margin-bottom:0.5rem;color:#111;">${line.arabic}</div>
+            <div style="border-left:3px solid #6c3fa0;padding-left:0.75rem;color:#444;margin-bottom:0.6rem;font-style:italic;">${line.translation}</div>
+            <ul style="margin:0;padding-left:1.25rem;color:#555;line-height:1.8;">
+              ${line.phrases.map((p) => `<li><span style="font-family:'Geeza Pro',serif;">${p.arabic}</span> = ${p.english}</li>`).join('')}
+            </ul>
+          </div>`
+        )
+        .join('');
+      body.style.display = 'block';
+      btn.textContent = 'Hide Word Breakdown';
+      showing = true;
+    } else {
+      body.style.display = 'none';
+      btn.textContent = 'Show Word Breakdown';
+      showing = false;
+    }
+  });
+}
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 let inited = false;
@@ -307,6 +386,7 @@ function tryCleanup(): void {
     cleanupPage();
     renderHarakatToggle(lyrics);
     renderTranslation(lyrics);
+    renderBreakdown(lyrics);
     const songTitle = document.querySelector('h1')?.textContent?.trim();
     if (songTitle) document.title = songTitle;
   }

--- a/test/visual.html
+++ b/test/visual.html
@@ -83,6 +83,40 @@
                     'Carry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place\nCarry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place\n\nGod bless you, my sister, and bring you joy\nLike a horse dancing in moonlight every time it appears before you\nAnd the face of goodness shines upon you like a radiant sun\nYou chose the finest groom, his heart sweet as sugar\n\nCarry the moon, O people of the house, the moon walks gracefully\nWhile the neighbors sing, our bride lights up the place',
                 });
               }, 300);
+            } else if (msg.action === 'breakdown') {
+              setTimeout(function () {
+                callback({
+                  result: JSON.stringify([
+                    {
+                      arabic: 'زفوا القمر يا أهل الدار القمر ماشي غندرة',
+                      translation: 'Carry the moon, O people of the house, the moon walks gracefully',
+                      phrases: [
+                        { arabic: 'زفوا', english: 'carry/escort in a wedding procession' },
+                        { arabic: 'أهل الدار', english: 'people of the house (the family)' },
+                        { arabic: 'غندرة', english: 'graceful, coquettish movement' },
+                      ],
+                    },
+                    {
+                      arabic: 'عم بيغنوا حجار الدار عروستنا منورة',
+                      translation: 'The neighbors are singing, our bride lights up the place',
+                      phrases: [
+                        { arabic: 'عم بيغنوا', english: 'they are singing (dialect progressive)' },
+                        { arabic: 'حجار الدار', english: 'neighbors (lit. "stones of the house")' },
+                        { arabic: 'منورة', english: 'radiant, lit up (fem.) — high praise' },
+                      ],
+                    },
+                    {
+                      arabic: 'برقص خيل بضوي الليل كل ما بطلع فيكي',
+                      translation: 'Dancing like horses lighting up the night every time I look at you',
+                      phrases: [
+                        { arabic: 'برقص خيل', english: 'dancing like horses — lively, spirited movement' },
+                        { arabic: 'بضوي الليل', english: 'you light up the night' },
+                        { arabic: 'بطلع فيكي', english: 'I look at you (dialect: بطلع = I look/emerge)' },
+                      ],
+                    },
+                  ]),
+                });
+              }, 300);
             } else {
               callback({ error: 'Unknown action' });
             }


### PR DESCRIPTION
## Summary
- New Lambda action `breakdown` returns JSON: per-line Arabic, full English translation, and key phrase glosses
- Frontend renders each line as: Arabic (RTL, large) → italic translation with purple left bar → bullet list of `phrase = meaning`
- Strips markdown code fences from response in case model wraps JSON
- Bumps `max_new_tokens` 4096 → 8192 to handle longer song breakdowns
- Visual test harness updated with mock breakdown response

🤖 Generated with [Claude Code](https://claude.com/claude-code)